### PR TITLE
Update action to Node.js 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ inputs:
     required: false
     default: ''
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'index.js'
 branding:
   icon: 'check-square'  


### PR DESCRIPTION
This PR updates `action.yml` to Node.js v20 as GitHub stopped supporting v12 and v16 a long time ago.